### PR TITLE
Forks driver-toolkit base-image and fixes buildconfig

### DIFF
--- a/buildconfigs/10-driver-toolkit.yaml
+++ b/buildconfigs/10-driver-toolkit.yaml
@@ -3,10 +3,6 @@ kind: BuildConfig
 metadata:
   name: driver-toolkit
   namespace: okd
-  failureDescription: |
-    STEP 5/17: RUN echo ${RHEL_VERSION} > /etc/yum/vars/releasever && yum config-manager --best --setopt=install_weak_deps=False --save
-    No such command: config-manager. Please use /usr/bin/yum --help
-    It could be a YUM plugin command, try: "yum install 'dnf-command(config-manager)'"
 spec:
   source:
     type: Git
@@ -17,14 +13,15 @@ spec:
     images:
       - from:
           kind: ImageStreamTag
-          name: 'release:builder'
-        as:
-          - 'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11'
+          name: 'release:forked-dockerfiles'
+        paths:
+          - sourcePath: /code/driver-toolkit/Dockerfile.centos9
+            destinationDir: "./"
   strategy:
     type: Docker
     dockerStrategy:
       imageOptimizationPolicy: SkipLayers
-      dockerfilePath: Dockerfile
+      dockerfilePath: Dockerfile.centos9
       from:
         kind: "ImageStreamTag"
         name: "release:base"

--- a/forks/driver-toolkit/Dockerfile.centos9
+++ b/forks/driver-toolkit/Dockerfile.centos9
@@ -1,0 +1,71 @@
+FROM registry.ci.openshift.org/ocp/4.12:base
+ARG KERNEL_VERSION=''
+ARG RT_KERNEL_VERSION=''
+ARG RHEL_VERSION=''
+RUN echo ${RHEL_VERSION} > /etc/yum/vars/releasever \
+    && yum install -y dnf-plugins-core && yum config-manager --best --setopt=install_weak_deps=False --save
+
+# kernel packages needed to build drivers / kmods
+RUN yum -y install \
+    kernel-core${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-devel${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-headers${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-modules${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    kernel-modules-extra${KERNEL_VERSION:+-}${KERNEL_VERSION} \
+    && yum clean all
+
+RUN if [ $(arch) = x86_64 ] && grep -q '^ID="centos"' /etc/os-release; then \
+    dnf config-manager --set-enabled rt; \
+    fi
+
+# real-time kernel packages
+RUN if [ $(arch) = x86_64 ]; then \
+    yum -y install \
+    kernel-rt-core${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION} \
+    kernel-rt-devel${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION} \
+    kernel-rt-modules${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION} \
+    kernel-rt-modules-extra${RT_KERNEL_VERSION:+-}${RT_KERNEL_VERSION} \
+    && yum clean all ; fi
+
+# Additional packages that are mandatory for driver-containers
+RUN yum -y install elfutils-libelf-devel kmod binutils kabi-dw && yum clean all
+
+# TODO[validate] replaced kernel-abi-whitelists with kernel-abi-stablelists: ref. https://bugzilla.redhat.com/show_bug.cgi?id=1953486
+RUN [ $(source /etc/os-release && echo $VERSION | cut -d'.' -f1) -gt 8 ] && \
+    yum -y install kernel-abi-stablelists || yum install -y install kernel-abi-whitelists ; \
+    yum clean all
+
+# Find and install the GCC version used to compile the kernel
+# If it cannot be found (fails on some architecutres), install the default gcc
+RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core) \
+&& GCC_VERSION=$(cat /lib/modules/${INSTALLED_KERNEL}/config | grep -Eo "Compiler: gcc \(GCC\) ([0-9\.]+)" | grep -Eo "([0-9\.]+)") \
+&& yum -y install gcc-${GCC_VERSION} \
+|| yum -y install gcc && \
+yum clean all
+
+# Additional packages that are needed for a subset (e.g DPDK) of driver-containers
+RUN yum -y install xz diffutils \
+    && yum clean all
+
+# Packages needed to build driver-containers
+RUN yum -y install git make \
+    && yum clean all
+
+# Packages needed to sign and run externally build kernel modules
+RUN if [ $(arch) == "x86_64" ] || [ $(arch) == "aarch64" ]; then \
+    ARCH_DEP_PKGS="mokutil"; fi \
+    && yum -y install openssl keyutils $ARCH_DEP_PKGS \
+    && yum clean all
+
+COPY manifests /manifests
+
+LABEL io.k8s.description="driver-toolkit is a container with the kernel packages necessary for building driver containers for deploying kernel modules/drivers on OpenShift" \
+      name="driver-toolkit" \
+      io.openshift.release.operator=true \
+      version="0.1"
+
+# Last layer for metadata for mapping the driver-toolkit to a specific kernel version
+RUN export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-core); \
+    export INSTALLED_RT_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}"  kernel-rt-core); \
+    echo "{ \"KERNEL_VERSION\": \"${INSTALLED_KERNEL}\", \"RT_KERNEL_VERSION\": \"${INSTALLED_RT_KERNEL}\", \"RHEL_VERSION\": \"${RHEL_VERSION}\" }" > /etc/driver-toolkit-release.json
+


### PR DESCRIPTION
This PR forks the driver-toolkit to build it using centos9 as a base with the following changes:

- installs dnf-plugins-core
- adds the `rt` repo to install the real-time kernel for centos base-images
- Installs kernel-abi-stablelists rather than kernel-abi-whitelists for cs/el > 8 (need validation, see the todo comment)


cc @vrutkovs @LorbusChris 