### PR TITLE
deployer: build from cli image, not base

### DIFF
--- a/buildconfigs/20-deployer.yaml
+++ b/buildconfigs/20-deployer.yaml
@@ -10,12 +10,6 @@ spec:
       uri: 'https://github.com/openshift/oc'
       ref: release-4.12
     contextDir: images/deployer
-    images:
-      - from:
-          kind: ImageStreamTag
-          name: 'release:builder'
-        as:
-          - 'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11'
   strategy:
     type: Docker
     dockerStrategy:
@@ -23,7 +17,7 @@ spec:
       dockerfilePath: Dockerfile.rhel
       from:
         kind: "ImageStreamTag"
-        name: "release:base"
+        name: "release:cli"
   output:
     to:
       kind: ImageStreamTag

--- a/pipelines/full-rebuild.yaml
+++ b/pipelines/full-rebuild.yaml
@@ -187,7 +187,6 @@ spec:
           - csi-node-driver-registrar
           - csi-snapshot-controller
           - csi-snapshot-validation-webhook
-          - deployer
           - docker-builder
           - docker-registry
     - name: batch-09
@@ -366,6 +365,7 @@ spec:
           - haproxy-router
           - ovn-kubernetes
           - machine-os-images
+          - deployer
     - name: batch-19
       runAfter:
       - batch-18


### PR DESCRIPTION
deployer base image needs to be `cli` as it merely copies binary from it