### PR TITLE
Bump replaced base-image for installer-artifacts to golang1.18/openshift4.12

### DIFF
--- a/buildconfigs/10-installer-artifacts.yaml
+++ b/buildconfigs/10-installer-artifacts.yaml
@@ -15,7 +15,7 @@ spec:
           kind: ImageStreamTag
           name: 'release:builder'
         as:
-          - 'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11'
+          - 'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12'
   strategy:
     type: Docker
     dockerStrategy:


### PR DESCRIPTION
cc @vrutkovs @LorbusChris 

