### PR TITLE
Bump base images and minor fixes for multi-arch

### DIFF
--- a/buildconfigs/10-ironic-machine-os-downloader.yaml
+++ b/buildconfigs/10-ironic-machine-os-downloader.yaml
@@ -15,7 +15,7 @@ spec:
           kind: ImageStreamTag
           name: 'release:builder'
         as:
-          - 'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10'
+          - 'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12'
   strategy:
     type: Docker
     dockerStrategy:

--- a/buildconfigs/10-openshift-controller-manager.yaml
+++ b/buildconfigs/10-openshift-controller-manager.yaml
@@ -15,7 +15,7 @@ spec:
           kind: ImageStreamTag
           name: 'release:builder'
         as:
-          - 'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10'
+          - 'registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11'
   strategy:
     type: Docker
     dockerStrategy:

--- a/forks/machine-os-images/Dockerfile.centos9
+++ b/forks/machine-os-images/Dockerfile.centos9
@@ -4,7 +4,7 @@ ARG DIRECT_DOWNLOAD=false
 
 USER root:root
 
-RUN dnf install -y jq wget https://kojihub.stream.centos.org/kojifiles/packages/coreos-installer/0.11.0/3.el8/x86_64/coreos-installer-0.11.0-3.el8.x86_64.rpm
+RUN dnf install -y jq wget https://kojihub.stream.centos.org/kojifiles/packages/coreos-installer/0.11.0/3.el8/$(arch)/coreos-installer-0.11.0-3.el8.$(arch).rpm
 COPY fetch_image.sh /usr/local/bin/
 RUN /usr/local/bin/fetch_image.sh
 

--- a/forks/tests/Dockerfile.centos9
+++ b/forks/tests/Dockerfile.centos9
@@ -7,7 +7,7 @@ RUN make; \
 
 FROM registry.ci.openshift.org/ocp/4.11:tools
 COPY --from=builder /tmp/build/openshift-tests /usr/bin/
-RUN PACKAGES="git gzip util-linux" && \
+RUN PACKAGES="git gzip util-linux python3-six" && \
     if [ $HOSTTYPE = x86_64 ] || [ $HOSTTYPE = ppc64le ]; then PACKAGES="$PACKAGES python3-cinderclient"; fi && \
     yum install -y centos-release-openstack-yoga && \
     yum install --setopt=tsflags=nodocs -y $PACKAGES && \


### PR DESCRIPTION
Fixes:

- bc for ironic-machine-os-downloader and the openshift-controller-manager that has changed upstream for 4.12
- the machine-os-images dockerfile, that had some hard coded ref to the amd64 architecture
- at least on arm64 the `python3-six` is not already installed when building tests causing the next `update` command to fail 